### PR TITLE
Fix loading images for marks in node.js

### DIFF
--- a/vega.js
+++ b/vega.js
@@ -3076,7 +3076,7 @@ vg.data.size = function(size, group) {
 
   function http(url, callback) {
     vg.log('LOAD HTTP: ' + url);
-    var options = {url: url};
+    var options = {url: url, encoding: null};
     if (vg.config.dataHeaders) {
       options.headers = vg.config.dataHeaders;
     }


### PR DESCRIPTION
This patch fixing generating PNGs with marks for node.js. Browser generation works fine too.
